### PR TITLE
Next.js Configuration Update for Vercel Deployment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Enable experimental features for appDir support
+  experimental: {
+    appDir: true,
+  },
+  // Disable static exports since you're deploying to Vercel
+  output: 'standalone',
+  // Enable React strict mode for better development
+  reactStrictMode: true,
+  // Explicitly set the directory where pages are located
+  pageExtensions: ['tsx', 'ts', 'jsx', 'js'],
+  // Set the default build directory
+  distDir: '.next'
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Changes Made
- Updated `next.config.ts` with proper app directory support
- Added Prisma build configuration in package.json
- Configured proper build settings for Vercel deployment

## Problem Solved
This PR fixes the 404 error occurring during Vercel deployment by properly configuring Next.js to support the app directory structure and handle Prisma database operations.

Fixes #2 